### PR TITLE
:sparkles: (env.go, genConfig.go, jsonHander.go) パス連結部分の書き換え

### DIFF
--- a/lib/env.go
+++ b/lib/env.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"os"
+  "path/filepath"
 )
 
 func GetYtacPath() string {
@@ -9,10 +10,11 @@ func GetYtacPath() string {
 
 	if ytacPath == "" {
 		var homeDir, _ = os.UserHomeDir()
-		ytacPath = homeDir + "/ytac"
+    ytacPath = filepath.Join(homeDir, "/ytac")
 	}
 
-	ytacPath = ytacPath + ""
+  // ?
+	// ytacPath = ytacPath + ""
 
 	return ytacPath
 }

--- a/lib/genConfig.go
+++ b/lib/genConfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+  "path/filepath"
 
 	"github.com/fatih/color"
 
@@ -18,7 +19,7 @@ func GenConfig() {
 	fmt.Println("🔎 $YTACPATH: " + OutYtacPath)
 	fmt.Println("🔨 creating config..")
 	var configData string = config.DefaultConfig()
-	var err = ioutil.WriteFile(ytacPath+"/config.json", []byte(configData), 0644)
+	var err = ioutil.WriteFile(filepath.Join(ytacPath, "/config.json"), []byte(configData), 0644)
 	if err != nil {
 		fmt.Println("🔥 failed to create config")
 		fmt.Println("🔨 creating " + OutYtacPath + "..")

--- a/lib/jsonHandler.go
+++ b/lib/jsonHandler.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+  "path/filepath"
 
 	"github.com/hidemaruowo/ytac/config"
 	"github.com/tidwall/gjson"
@@ -14,7 +15,7 @@ var _config = readConfig()
 //readJson
 func readConfig() string {
 	var ytacPath string = GetYtacPath()
-	var configPath string = ytacPath + "/config.json"
+	var configPath string = filepath.Join(ytacPath, "/config.json")
 
 	var f, err = os.Open(configPath)
 	if err != nil {


### PR DESCRIPTION
パス連結部分に+演算子を用いるとバグの原因になるのでpath/filepath.Joinに書き換えました。また、無効な処理のコメントアウトをしました。